### PR TITLE
Linting, scans, and misc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ To help get your evaluation strategy up and running, this repository includes:
 
 [![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?#/stacks/create/review?templateURL=https://ws-assets-prod-iad-r-iad-ed304a55c2ca1aee.s3.us-east-1.amazonaws.com/ab6c96d3-53cf-4730-b0fe-f4762dbbb6eb/cfn_bootstrap.yaml&stackName=LLMEvalBootstrap "Launch Stack")
 
-Alternatively, to guarantee you're in sync with the latest code updates, you can download the [infra/cfn_bootstrap.yaml](infra/cfn_bootstrap.yaml) template and then [deploy it from the AWS CloudFormation console](https://console.aws.amazon.com/cloudformation/home?#/stacks/create).
+Alternatively, to guarantee you're in sync with the latest code updates, you can download the template from [infra/cfn_bootstrap.yaml](infra/cfn_bootstrap.yaml) and then [deploy it from the AWS CloudFormation console](https://console.aws.amazon.com/cloudformation/home?#/stacks/create).
+
+> ⚠️ **Note:** The above CloudFormation stacks create an AWS CodeBuild Project with broad IAM permissions to deploy the solution on your behalf. They're not recommended for use in production-environments where [least-privilege principles](https://aws.amazon.com/blogs/security/techniques-for-writing-least-privilege-iam-policies/) should be followed.
 
 If you'd like to **customize** your setup further, check out [infra/README.md](infra/README.md) for details on how to configure and deploy the infrastructure from the [AWS CDK](https://aws.amazon.com/cdk/) source code.
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -22,6 +22,8 @@ The data-driven prompt engineering app is provided as a basic example of how aut
 2. We provide a Python ["data model"](prompt_app/src/datamodel) that attempts to describe sensible abstractions for configuration management of e.g. models, inference parameters, prompt templates, etc... But haven't yet implemented persistent storage for these objects. A fully-featured solution could consider NoSQL storage options like Amazon DynamoDB.
 3. Although Streamlit is useful for quick UI prototyping with teams familiar with Python, it's not a fully-featured web UI development framework. Before investing in building more advanced UI features and workflow improvements, consider whether your long-term requirements would merit switching to something else.
 
+For a detailed list of other security configurations you might want to optimize before using the stack in prodution, you can enable [cdk-nag](https://github.com/cdklabs/cdk-nag) by running the build with the `CDK_NAG=true` environment variable or editing the defaults in [cdk_app.py](cdk_app.py). You don't need to request stack deployment to complete this analysis: running `npx cdk synth` would show the same error list.
+
 
 ## Development environment pre-requisites
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -2,16 +2,16 @@
 
 This project includes a containerized prompt engineering / evaluation demo app, infrastructure-as-code to deploy it, and additional code to deploy an [Amazon SageMaker Studio Domain](https://docs.aws.amazon.com/sagemaker/latest/dg/sm-domain.html) pre-configured ready to use in a guided workshop setting (in case you don't have one already).
 
-This guide is intended mainly for developers wishing to understand and customize the provided infrastructure. If you just want to deploy it as-is in your AWS Account, consider using the [cfn_bootstrap.yaml](cfn_bootstrap.yaml) template in [AWS CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-create-stack.html).
-
 
 ## Architecture overview
 
-The demo app is built in Python with [Streamlit](https://streamlit.io/) (see the [prompt_app folder](prompt_app)) and deployed as an [ECS Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html) serverless container, behind an [Application Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html) via the [`ApplicationLoadBalancedFargateService` CDK construct](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs_patterns.ApplicationLoadBalancedFargateService.html). Users connect over HTTPS through [Amazon CloudFront](https://aws.amazon.com/cloudfront/), and log in with authentication provided by an [Amazon Cognito User Pool](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools.html).
+The demo app is built in Python with [Streamlit](https://streamlit.io/) (see the [prompt_app folder](prompt_app)) and deployed as an [ECS Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html) serverless container, behind an [Application Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html) (via the [`ApplicationLoadBalancedFargateService` CDK construct](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs_patterns.ApplicationLoadBalancedFargateService.html)). Users connect over HTTPS through [Amazon CloudFront](https://aws.amazon.com/cloudfront/), and log in with authentication provided by an [Amazon Cognito User Pool](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools.html).
 
 ![](images/architecture-overview.png "Architecture overview diagram depicting the above-described chain, with the ECS Fargate app also connecting out to foundation models on either Amazon Bedrock or OpenAI.")
 
 The above infrastructure, and the optional SageMaker Studio Domain deployment, is implemented in and deployed through [AWS CDK for Python](https://aws.amazon.com/cdk/). Since deploying CDK code requires setting up a development environment (as detailed below), we also provide a directly-deployable ["bootstrap" CloudFormation template](cfn_bootstrap.yaml) which fetches this repository and runs the CDK deploment via [AWS CodeBuild](https://aws.amazon.com/codebuild/).
+
+> ⚠️ **Note:** The above CloudFormation template creates an AWS CodeBuild Project with broad IAM permissions to deploy the solution on your behalf. It's not recommended for use in production-environments where [least-privilege principles](https://aws.amazon.com/blogs/security/techniques-for-writing-least-privilege-iam-policies/) should be followed.
 
 
 ## Important caveats

--- a/infra/cdk_app.py
+++ b/infra/cdk_app.py
@@ -9,6 +9,7 @@ import os
 
 # External Dependencies:
 import aws_cdk as cdk
+from cdk_nag import AwsSolutionsChecks  # (Optional stack security checks)
 
 # Local Dependencies:
 from cdk_src.cdk_stack import LLMEValWKshpStack
@@ -17,6 +18,8 @@ from cdk_src.config_utils import bool_env_var
 # Top-level configurations are loaded from environment variables at the point `cdk synth` or
 # `cdk deploy` is run (or you can override here):
 config = {
+    # cdk_nag is a useful tool for auditing configuration security, but can sometimes be noisy:
+    "cdk_nag": bool_env_var("CDK_NAG", default=False),
     "deploy_prompt_app": bool_env_var("DEPLOY_PROMPT_APP", default=True),
     "deploy_sagemaker_domain": bool_env_var("DEPLOY_SAGEMAKER_DOMAIN", default=True),
     "sagemaker_code_checkout": os.environ.get("SAGEMAKER_CODE_CHECKOUT"),
@@ -28,6 +31,16 @@ config = {
 
 app = cdk.App()
 print(f"Preparing stack with configuration:\n{json.dumps(config, indent=2)}")
-llm_eval_wkshp_stack = LLMEValWKshpStack(app, "LLMEValWKshpStack", **config)
+llm_eval_wkshp_stack = LLMEValWKshpStack(
+    app,
+    "LLMEValWKshpStack",
+    **{k: v for k, v in config.items() if k != "cdk_nag"},
+)
+
+if config["cdk_nag"]:
+    print("Adding cdk_nag checks")
+    cdk.Aspects.of(app).add(AwsSolutionsChecks())
+else:
+    print("Skipping cdk_nag checks")
 
 app.synth()

--- a/infra/cdk_src/cdk_stack.py
+++ b/infra/cdk_src/cdk_stack.py
@@ -37,7 +37,9 @@ class LLMEValWKshpStack(Stack):
                 vpc=vpc,
                 code_checkout=sagemaker_code_checkout,
                 code_repo=sagemaker_code_repo,
+                create_nbi=False,  # Don't create a 'Notebook Instance' (save costs, use Studio)
                 instance_type="ml.t3.large",
+                studio_classic=False,  # Keep SMStudio classic disabled (save costs)
             )
 
         if deploy_prompt_app:

--- a/infra/cdk_src/prompt_app.py
+++ b/infra/cdk_src/prompt_app.py
@@ -88,10 +88,11 @@ class PromptEngineeringApp(Construct):
             cognito_user_pool = cognito.UserPool(
                 self,
                 "UserPool",
+                advanced_security_mode=cognito.AdvancedSecurityMode.ENFORCED,
+                removal_policy=RemovalPolicy.DESTROY,
                 self_sign_up_enabled=False,
                 sign_in_aliases=cognito.SignInAliases(username=True, email=True),
                 sign_in_case_sensitive=False,
-                removal_policy=RemovalPolicy.DESTROY,
             )
         self._cognito_user_pool = cognito_user_pool
         user_pool_client = cognito.UserPoolClient(

--- a/infra/cdk_src/smstudio/cr_lambda_common.py
+++ b/infra/cdk_src/smstudio/cr_lambda_common.py
@@ -29,8 +29,9 @@ class SMCustomResourceHelperLayer(PythonLayerVersion):
         bundling: BundlingOptions | Dict[str, Any] | None = None,
         compatible_architectures: Sequence[Architecture] | None = None,
         compatible_runtimes: Sequence[Runtime] | None = None,
-        description: str
-        | None = ("Helper functions & classes for SageMaker CloudFormation custom resources"),
+        description: str | None = (
+            "Helper functions & classes for SageMaker CloudFormation custom resources"
+        ),
         layer_version_name: str | None = None,
         license: str | None = None,
         removal_policy: RemovalPolicy | None = None,

--- a/infra/cdk_src/smstudio/cr_lambda_common/sagemaker_util.py
+++ b/infra/cdk_src/smstudio/cr_lambda_common/sagemaker_util.py
@@ -1,0 +1,28 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Shared utilities for CloudFormation Custom Resources working with SageMaker"""
+# Python Built-Ins:
+import logging
+import time
+from typing import Callable, TypeVar
+
+# External Dependencies:
+from botocore.exceptions import ClientError
+
+
+logger = logging.getLogger("sagemaker_util")
+TResponse = TypeVar("TResponse")
+
+
+def retry_if_already_updating(fn: Callable[[], TResponse], delay_secs: float = 10) -> TResponse:
+    """Retry `fn` every `delay_secs` if it fails because a SageMaker Domain is already updating"""
+    while True:
+        try:
+            return fn()
+        except ClientError as err:
+            if "is already being updated" in err.response["Error"]["Message"]:
+                logger.info("Domain already updating - waiting to retry...")
+                time.sleep(delay_secs)
+                continue
+            else:
+                raise err

--- a/infra/cdk_src/smstudio/domain/fn_domain/main.py
+++ b/infra/cdk_src/smstudio/domain/fn_domain/main.py
@@ -48,6 +48,7 @@ import boto3
 
 # Local Dependencies:
 from cfn import CustomResourceEvent, CustomResourceRequestType, parse_cfn_boolean
+from sagemaker_util import retry_if_already_updating
 import vpctools
 
 logger = logging.getLogger("main")
@@ -317,9 +318,11 @@ def delete_domain(domain_id: str):
 
 
 def update_domain(domain_id: str, default_user_settings):
-    response = smclient.update_domain(
-        DomainId=domain_id,
-        DefaultUserSettings=default_user_settings,
+    retry_if_already_updating(
+        lambda: smclient.update_domain(
+            DomainId=domain_id,
+            DefaultUserSettings=default_user_settings,
+        ),
     )
     updated = False
     time.sleep(0.5)

--- a/infra/cdk_src/smstudio/lcc/__init__.py
+++ b/infra/cdk_src/smstudio/lcc/__init__.py
@@ -69,12 +69,12 @@ class SageMakerNotebookLifecycleConfig(Construct):
             self,
             id,
             notebook_instance_lifecycle_config_name=name,  # (Name prop is mandatory)
-            on_create=[self._script_to_lcc_hook_property(on_create_script)]
-            if on_create_script
-            else None,
-            on_start=[self._script_to_lcc_hook_property(on_start_script)]
-            if on_start_script
-            else None,
+            on_create=(
+                [self._script_to_lcc_hook_property(on_create_script)] if on_create_script else None
+            ),
+            on_start=(
+                [self._script_to_lcc_hook_property(on_start_script)] if on_start_script else None
+            ),
         )
 
     @staticmethod

--- a/infra/cfn_bootstrap.yaml
+++ b/infra/cfn_bootstrap.yaml
@@ -11,6 +11,7 @@ Description: |-
   permissions to CodeBuild - not recommended for use in production environments.
 
 Parameters:
+  # TODO: Would be nice to support https:// S3 zip URLs here rather than only git repositories
   CodeRepo:
     Type: String
     Default: https://github.com/aws-samples/llm-evaluation-methodology
@@ -53,6 +54,13 @@ Metadata:
 Resources:
   CodeBuildServiceRole:
     Type: "AWS::IAM::Role"
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W11
+            reason: "Not recommended for use in production environments: Grants CodeBuild broad access to deploy/destroy the CDK solution without scoping down individual required services & resources"
+          - id: W44
+            reason: "Not recommended for use in production environments: Grants CodeBuild broad access to deploy/destroy the CDK solution without scoping down individual required services & resources"
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -92,6 +100,11 @@ Resources:
 
   CodeBuildProject:
     Type: "AWS::CodeBuild::Project"
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W32
+            reason: "Use default S3 encryption - no actual artifacts being created"
     Properties:
       Artifacts:
         Type: NO_ARTIFACTS
@@ -192,12 +205,14 @@ Resources:
                 - lambda.amazonaws.com
             Action:
               - "sts:AssumeRole"
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole' # (CloudWatch Logs)
       Policies:
         - PolicyName: RunCodeBuildProject
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
-              - Sid: IAMAccess
+              - Sid: RunCodeBuild
                 Effect: Allow
                 Action:
                   - "codebuild:StartBuild"
@@ -206,6 +221,13 @@ Resources:
 
   CodeBuildTriggerFunction:
     Type: "AWS::Lambda::Function"
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W89
+            reason: "IAM will authorize access to this rarely-used function: No need to put in VPC"
+          - id: W92
+            reason: "Only to be invoked by CREATE/UPDATE/DELETE CFN events for this stack: no reserved concurrency required"
     Properties:
       Description: "CloudFormation custom resource implementation for running CodeBuild project"
       Code:

--- a/infra/package.json
+++ b/infra/package.json
@@ -12,8 +12,11 @@
     "dev:watchlogs": "while :; do clear; docker compose logs -f; sleep 2; done",
     "deploy": "npm run login:ecrpublic && cdk deploy --all",
     "destroy": "cdk destroy --all",
-    "lint": "black ./cdk_src ./prompt_app/src",
+    "lint:cfn": "cfn-lint cfn_bootstrap.yaml",
+    "lint:python": "black ./cdk_src ./prompt_app/src",
+    "lint": "npm run lint:cfn && npm run lint:python",
     "login:ecrpublic": "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws",
+    "scan:cfn": "cfn_nag_scan --input-path cfn_bootstrap.yaml",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [

--- a/infra/prompt_app/src/requirements.txt
+++ b/infra/prompt_app/src/requirements.txt
@@ -1,4 +1,4 @@
-fmeval==1.0.0
+fmeval>=1.0.3,<1.1
 # Explicit pandas v for: https://github.com/ray-project/ray/issues/42572
 # https://discuss.ray.io/t/pandas-importerror-with-ray-data-dataset-show/13486
 pandas<2.2.0

--- a/infra/requirements-dev.txt
+++ b/infra/requirements-dev.txt
@@ -1,2 +1,3 @@
 black==24.3.0
+cfn-lint==0.87
 pytest==6.2.5

--- a/infra/requirements.txt
+++ b/infra/requirements.txt
@@ -5,5 +5,6 @@
 # See: https://github.com/aws/aws-cdk/issues/30067
 aws-cdk-lib==2.140.0
 aws-cdk.aws-lambda-python-alpha==2.140.0-alpha.0
+cdk-nag==2.28
 constructs>=10.0.0,<11.0.0
 upsert-slr>=1.0.2,<2


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

- IaC scanning for improved security/operational excellence: Enable cfn-nag, cfn-lint, and install cdk-nag but leave it disabled by default by now as too many findings to deal with yet.
- Enable advanced security option on Cognito
- Grant bootstrap CFn Lambda permission to write its logs to CloudWatch
- Fix (again) issue where multiple sagemaker:UpdateDomain calls could clash during stack deployment
- Cut out creation of SM Notebook Instance and Studio Classic resources to save costs for users running (the workshop only uses new SM Studio)
- Consume bugfixes from fmeval

Tested in fresh workshop environment

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
