### PR TITLE
Add perf test notebook for LLMeter+FMBench

### DIFF
--- a/Latency and Cost.ipynb
+++ b/Latency and Cost.ipynb
@@ -26,7 +26,7 @@
    "outputs": [],
    "source": [
     "# (list botocore to help pip find the existing installation and speed things up)\n",
-    "%pip install botocore \"llmeter[plotting]>=0.1.2,<0.2\" \"transformers>=4.30,<5\""
+    "%pip install botocore \"llmeter[plotting]>=0.1.3,<0.2\" \"transformers>=4.30,<5\""
    ]
   },
   {
@@ -161,7 +161,7 @@
     "    output_path=f\"data/llmeter/{bedrock_endpoint_stream.model_id}/heatmap\",\n",
     "    source_file=\"datasets/MaryShelleyFrankenstein.txt\",\n",
     "    input_lengths=[50, 500, 1000],\n",
-    "    output_lengths=[128, 512, 1024],\n",
+    "    output_lengths=[128, 256, 512],\n",
     "    create_payload_fn=prompt_fn,\n",
     ")\n",
     "\n",
@@ -252,7 +252,9 @@
    "id": "d36021a7-167a-4c32-aae9-2b0409e82e9c",
    "metadata": {},
    "source": [
-    "Once the target endpoint is set up, we can run a `LoadTest` by defining what concurrency levels we'd like to test and how many requests should be sent for each one:"
+    "Once the target endpoint is set up, we can run a `LoadTest` by defining what concurrency levels we'd like to test and how many requests should be sent for each one:\n",
+    "\n",
+    "> ℹ️ **Note:** You may see some *error messages* about time-outs or throttling errors when running the below. This is totally normal, as we're testing the endpoint with heavy load! Your test should continue to run through these errors and `sweep_results` should still be accessible afterwards."
    ]
   },
   {

--- a/Latency and Cost.ipynb
+++ b/Latency and Cost.ipynb
@@ -1,0 +1,546 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5f08795c-7020-433b-8624-37ee397519c4",
+   "metadata": {},
+   "source": [
+    "# Testing LLM latency, throughput, and price-performance\n",
+    "\n",
+    "> *This notebook has been tested in the Python 3 kernel of SageMaker Studio JupyterLab (Distribution v2.0)*\n",
+    "\n",
+    "Response quality and robustness of LLM-powered applications must also be contextualized by their **speed** and **cost**: Because slow latencies or high prices could prevent a solution from being viable, and a wide *range of models are available* with different trade-offs between these parameters.\n",
+    "\n",
+    "This notebook briefly demonstrates two open-source tools you can use to test and compare LLM (application)s' response speeds and consider the implications for cost-of-ownership: [LLMeter](https://pypi.org/project/llmeter/) and [FMBench](https://github.com/aws-samples/foundation-model-benchmarking-tool).\n",
+    "\n",
+    "The two halves are independent, but both assume you've deployed example SageMaker JumpStart endpoints as detailed in the [accompanying guided workshop](https://catalog.workshops.aws/workshops/ab6c96d3-53cf-4730-b0fe-f4762dbbb6eb/en-US/20-model-shortlisting/21-model-setup). We also recommend installing the dependencies up-front so you can move between halves without having to restart your notebook kernel:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4446e37b-e1ef-4b63-935e-053b45270b7d",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# (list botocore to help pip find the existing installation and speed things up)\n",
+    "%pip install botocore \"llmeter[plotting]>=0.1.2,<0.2\" \"transformers>=4.30,<5\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e68c1fed-8f31-4635-900e-ac7ffc430a62",
+   "metadata": {},
+   "source": [
+    "## Lightweight latency and throughput testing with LLMeter\n",
+    "\n",
+    "LLMeter (on [PyPI](https://pypi.org/project/llmeter/) and [GitHub](https://github.com/awslabs/llmeter)) offers simple but extensible tools for performance testing LLMs hosted on a wide range of platforms.\n",
+    "\n",
+    "It offers out-of-the-box analyses of:\n",
+    "\n",
+    "- **Latency by input & output token count**: Helping you understand the impact of your generation lengths and input prompt lengths on response speed\n",
+    "- **Latency and throughput by concurrent requests**: Exploring how container/server-based deployment models behave under load\n",
+    "\n",
+    "...and the ability to create other custom \"experiments\" on top of the core instrumentation framework, if you need."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0797158-6e46-401f-bc56-f0a8c2cab61c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llmeter.endpoints import BedrockConverseStream, SageMakerStreamEndpoint\n",
+    "from llmeter.experiments import LatencyHeatmap, LoadTest\n",
+    "\n",
+    "# We'll also use some utilities fetching example payloads for SM JumpStart endpoints:\n",
+    "from sagemaker.jumpstart.model import JumpStartModel\n",
+    "from sagemaker.jumpstart.session_utils import get_model_info_from_endpoint"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93c45e13-cf76-4b9d-bb74-fedc77841c81",
+   "metadata": {},
+   "source": [
+    "### Latency heatmapping by I/O token counts\n",
+    "\n",
+    "First, we'll need to set up an LLMeter \"endpoint\" object to connect our chosen model/API with instrumentation. In this example, we'll target Anthropic Claude 3 Haiku on Amazon Bedrock - with **response streaming** enabled:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7de2e8f8-7700-4b15-ba1b-d1eef5cab191",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bedrock_endpoint_stream = BedrockConverseStream(\n",
+    "    model_id=\"anthropic.claude-3-haiku-20240307-v1:0\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8ef4111-4c11-497a-92fb-08839be1434e",
+   "metadata": {},
+   "source": [
+    "This endpoint provides a mechanism to invoke the model, but also track latency metrics of the invocation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22dacea0-0f49-4481-929e-c8587a8d2e4c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample_response = bedrock_endpoint_stream.invoke(\n",
+    "    payload=BedrockConverseStream.create_payload(\n",
+    "        \"Create a list of 3 pop songs\",\n",
+    "        max_tokens=512,\n",
+    "        system=[{\"text\": \"you're an expert in pop and indie music\"}],\n",
+    "    ),\n",
+    ")\n",
+    "print(sample_response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f98b0b89-4a61-411b-8518-6ff84e5d4709",
+   "metadata": {},
+   "source": [
+    "> ℹ️ **Note:** We're using the *streaming* variant of the endpoint here, which means the \"Time-to-First Token\" metric is also available. If your use-case is not able to consume streaming responses, you may see more accurate/representative overall (Time-to-Last Token) latency metrics using the non-streaming `BedrockConverse` endpoint.\n",
+    "\n",
+    "For teams with an extensive, use-case representative dataset on hand - you could use LLMeter's [Runner](https://github.com/awslabs/llmeter/blob/main/llmeter/runner.py) class to run batch requests through the LLM and analyze the statistics by input and output token count. However, projects may need to perform initial investigations before such a dataset is available.\n",
+    "\n",
+    "LLMeter's \"Latency Heatmap\" experiment explores latency as a function of prompt length and completion length by *automatically* generating prompts of various lengths from a source text (with the aim of producing long outputs), and using the `max_tokens` inference parameter to limit generation lengths.\n",
+    "\n",
+    "Here we'll use the same source text as LLMeter's own examples: The text of short story \"Frankenstein\" by Mary Shelley:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "920a6e41-ae6a-4715-b452-7bd8de54cd03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl -o datasets/MaryShelleyFrankenstein.txt \\\n",
+    "    https://raw.githubusercontent.com/awslabs/llmeter/main/examples/MaryShelleyFrankenstein.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "984e642e-3c63-4ebe-a51a-d9adb2592214",
+   "metadata": {},
+   "source": [
+    "With a source text and a function (below) to format example requests from fragments of that text, we're ready to run our experiment to measure latency across various input and output lengths:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1892c258-0d61-4771-befd-a7155842d0bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def prompt_fn(prompt, **kwargs):\n",
+    "    formatted_prompt = f\"Create a story based on the following prompt: {prompt}\"\n",
+    "    return BedrockConverseStream.create_payload(\n",
+    "        formatted_prompt, inferenceConfig={\"temperature\": 1.0}, **kwargs\n",
+    "    )\n",
+    "\n",
+    "latency_heatmap = LatencyHeatmap(\n",
+    "    endpoint=bedrock_endpoint_stream,\n",
+    "    clients=4,\n",
+    "    requests_per_combination=20,\n",
+    "    output_path=f\"data/llmeter/{bedrock_endpoint_stream.model_id}/heatmap\",\n",
+    "    source_file=\"datasets/MaryShelleyFrankenstein.txt\",\n",
+    "    input_lengths=[50, 500, 1000],\n",
+    "    output_lengths=[128, 512, 1024],\n",
+    "    create_payload_fn=prompt_fn,\n",
+    ")\n",
+    "\n",
+    "heatmap_results = await latency_heatmap.run()\n",
+    "\n",
+    "fig, axs = latency_heatmap.plot_heatmap()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0cc79d42-f74f-4666-b640-ebc97a9b3cbc",
+   "metadata": {},
+   "source": [
+    "In our test, we found that the *Time-to-Last-Token* (the overall response time) correlated most strongly with the output token count - while the *Time-to-First-Token* (until the streaming response returned the first part of the response) correlated most strongly with the input prompt length.\n",
+    "\n",
+    "Note that we kept the parallel `clients` and total `requests_per_combination` small for this example to avoid running in to quota issues for large workshops. With only 20 requests per combination, **p99 results are not statistically significant**. You'll also see that the graphed input and output token counts don't correspond exactly to the test inputs. The lengths of generated input prompts are approximate based on a local tokenizer (you can pass in a `tokenizer` argument to provide something that corresponds more accurately with your model under test), and outputs may be truncated in cases where the model stops generating earlier than `max_tokens` - so the graphed bins are calculated automatically from the actual data obtained by the test.\n",
+    "\n",
+    "In addition to the visual output here in the notebook, you'll find that the plot and additional detail files have been saved to disk in the provided `output_path` - which could instead have been an `s3://...` URI to write directly to Amazon S3.\n",
+    "\n",
+    "The summary and full request-level details are also available here in Python, for more custom analyses:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ece70afa-fba5-465f-ad64-916af8081e84",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(heatmap_results.output_path)\n",
+    "\n",
+    "print(\"\\nResults summary:\")\n",
+    "print(heatmap_results)\n",
+    "\n",
+    "print(\"\\nIndividual invocation example:\")\n",
+    "print(heatmap_results.responses[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96d4771c-92a1-4da6-8f7b-a049061d347d",
+   "metadata": {},
+   "source": [
+    "### Load testing with concurrent requests\n",
+    "\n",
+    "For large-scale API-based services like Amazon Bedrock, the total request volume for a specific use-case is likely to be insignificant relative to the overall size of the service: So it's important to check and request appropriate [quotas](https://docs.aws.amazon.com/bedrock/latest/userguide/quotas.html) for your proposed usage, but there may be limited value in testing how latency varies with load.\n",
+    "\n",
+    "For deployment like Amazon SageMaker JumpStart, however, where you choose the **number and type of instances** on which to deploy your model - it's important to understand how your solution will behave under many concurrent requests, to configure your infrastructure and auto-scaling appropriately.\n",
+    "\n",
+    "LLMeter's **`LoadTest` experiment** provides a tool to test the latency and overall throughput your model endpoint can deliver as the number of concurrent requests increase.\n",
+    "\n",
+    "We'll run this test against one of the SageMaker JumpStart endpoints you deployed earlier (make sure the `sm_endpoint_name` below matches to one of your deployed endpoints!):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "813746fa-2929-47cb-b91d-65cdf49a3b43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sm_endpoint_name = \"demo-llama-3-8b-instruct\"  # <- Check this matches one of your endpoints!\n",
+    "\n",
+    "# Look up the JumpStart model ID from the SageMaker endpoint:\n",
+    "model_id, model_version, _, _, _ = get_model_info_from_endpoint(endpoint_name=sm_endpoint_name)\n",
+    "print(f\"{sm_endpoint_name} is a deployment of model ID:\\n    {model_id}\")\n",
+    "\n",
+    "# Look up example payloads from SageMaker JumpStart for this model:\n",
+    "smjs_model = JumpStartModel(model_id=model_id, model_version=model_version)\n",
+    "sample_payloads = [k.body for k in (smjs_model.retrieve_all_examples() or []) if k.body]\n",
+    "print(f\"Got {len(sample_payloads)} example request payloads for this model from SageMaker\")\n",
+    "\n",
+    "# Create the LLMeter 'endpoint':\n",
+    "sagemaker_endpoint = SageMakerStreamEndpoint(\n",
+    "    endpoint_name=sm_endpoint_name, model_id=model_id\n",
+    ")\n",
+    "\n",
+    "# Test the endpoint with one of the example payloads:\n",
+    "print(f\"\\nTesting endpoint with payload:\\n{sample_payloads[0]}\")\n",
+    "sample_response = sagemaker_endpoint.invoke(payload=sample_payloads[0])\n",
+    "\n",
+    "print(f\"Got result:\")\n",
+    "print(sample_response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d36021a7-167a-4c32-aae9-2b0409e82e9c",
+   "metadata": {},
+   "source": [
+    "Once the target endpoint is set up, we can run a `LoadTest` by defining what concurrency levels we'd like to test and how many requests should be sent for each one:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0d5715d-3800-42c7-9dd8-ad7e4b4802fb",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "sweep_test = LoadTest(\n",
+    "    endpoint=sagemaker_endpoint,\n",
+    "    payload=sample_payloads,\n",
+    "    sequence_of_clients=[1, 5, 20, 100, 200],\n",
+    "    min_requests_per_client=3,\n",
+    "    min_requests_per_run=20,\n",
+    "    output_path=f\"data/llmeter/{sagemaker_endpoint.model_id}/sweep\",\n",
+    ")\n",
+    "sweep_results = await sweep_test.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0dd97412-a002-4a22-a35a-38a60b797941",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loadfig, loadaxs = sweep_test.plot_sweep_results()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4850d4d4-46fc-4998-b410-99ba1dec9a31",
+   "metadata": {},
+   "source": [
+    "LLMeter does not attempt to integrate **pricing** information directly from cloud services, but in general you can relate the results to pricing in terms of:\n",
+    "- The observed total input and output lengths, for per-token pricing deployments like [base models on Amazon Bedrock](https://aws.amazon.com/bedrock/pricing/)\n",
+    "- The total test duration & achievable throughput in concurrent requests per minute, for per-infrastructure pricing deployments like [SageMaker JumpStart Endpoints](https://aws.amazon.com/sagemaker/pricing/)\n",
+    "\n",
+    "For more details on the low-level components in LLMeter, refer to their published [example notebooks](https://github.com/awslabs/llmeter/tree/main/examples)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2eea41be-e30d-4d0a-9613-45e682988669",
+   "metadata": {},
+   "source": [
+    "## A more involved, cost-aware setup with FMBench\n",
+    "\n",
+    "Another option for latency and load testing LLMs is [FMBench from AWS Samples](https://github.com/aws-samples/foundation-model-benchmarking-tool).\n",
+    "\n",
+    "FMBench offers extra functionality, including:\n",
+    "- Built-in awareness of AWS Pricing to link metrics to actual dollar costs\n",
+    "- Built-in options to deploy (and tear down) model endpoints as part of the test run\n",
+    "- Extra analyses on response quality, as well as speed/cost\n",
+    "\n",
+    "However, its larger scope makes it more complex to install and configure. In particular, FMBench's dependency on Python>=3.11 and range of tightly-pinned other dependencies make it challenging to install on a SageMaker Studio notebook. Generally, the tool works well when installed on its own independent environment away from other projects.\n",
+    "\n",
+    "If you deployed [this workshop's CloudFormation stack](https://github.com/aws-samples/llm-evaluation-methodology/tree/main#readme) with the performance testing stack enabled, a [SageMaker Pipeline](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines-overview.html) has already been set up encapsulating an FMBench workflow for you.\n",
+    "\n",
+    "> ℹ️ If the below SageMaker Pipeline isn't already set up in your environment, refer to the [deployment instructions](https://github.com/aws-samples/llm-evaluation-methodology/tree/main#readme) for extra guidance.\n",
+    "\n",
+    "Run the code below to look up your deployed FMBench pipeline and its default input parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8342364e-dc47-425e-87bc-cce4eef38a46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from sagemaker.workflow.pipeline import Pipeline\n",
+    "\n",
+    "fmbench_pipeline = Pipeline(\"sm-fmbench-pipeline\")\n",
+    "\n",
+    "# Look up the pre-created pipeline and its configured input parameters:\n",
+    "pipeline_desc = fmbench_pipeline.describe()\n",
+    "print(f\"Found existing FMBench pipeline '{fmbench_pipeline.name}'\")\n",
+    "\n",
+    "pipeline_defn = json.loads(pipeline_desc[\"PipelineDefinition\"])\n",
+    "pipeline_params = pipeline_defn[\"Parameters\"]\n",
+    "\n",
+    "print(\"\\nPipeline parameters:\")\n",
+    "print(json.dumps(pipeline_params, indent=2))\n",
+    "\n",
+    "try:\n",
+    "    default_config_s3uri = next(\n",
+    "        p for p in pipeline_params if p[\"Name\"] == \"ConfigS3Uri\"\n",
+    "    )[\"DefaultValue\"]\n",
+    "except StopIteration as e:\n",
+    "    raise ValueError(\n",
+    "        f\"Couldn't find 'ConfigS3Uri' parameter in pipeline parameters: {pipeline_params}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "230917b0-3389-441b-b05d-47895c731c67",
+   "metadata": {},
+   "source": [
+    "To get started, you should be able to directly invoke this pipeline with the default parameters either through the [\"Pipelines\" interface in the SageMaker Studio sidebar menu](https://docs.aws.amazon.com/sagemaker/latest/dg/run-pipeline.html), or by running the code cell below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "435ef08e-4bce-4373-946a-b03da086c742",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fmbench_execution_1 = fmbench_pipeline.start()\n",
+    "fmbench_execution_1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5809c51-d8d9-427d-8ca1-068443849a79",
+   "metadata": {},
+   "source": [
+    "While the pipeline runs (which may take several minutes), let's explore the configuration files that were pre-loaded to Amazon S3:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c24b1a62-f8ba-455f-9b24-4014c76ef378",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fmbench_config_s3root = \"/\".join(default_config_s3uri.split(\"/\")[:-2])\n",
+    "\n",
+    "print(fmbench_config_s3root + \"\\n\")\n",
+    "\n",
+    "!aws s3 sync {fmbench_config_s3root} data/fmbench_configs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ddcfd1d-8d7b-46e6-a922-f62d0046e162",
+   "metadata": {},
+   "source": [
+    "The downloaded folder should contain (at least) **two configurations** for FMBench experiments: One for Llama, and one for Mistral. Check out the [data/fmbench_configs folder](data/fmbench_configs) for these pre-prepared `config.yaml` examples.\n",
+    "\n",
+    "Note that in particular, the `ep_name` in the config YAML must exactly match the name of your deployed SageMaker endpoint. If you deployed your endpoint with a different name, you may need to edit this file and then re-upload it to S3 for your pipeline to work correctly.\n",
+    "\n",
+    "You can check the status of your running pipeline execution in the SageMaker Studio Pipelines UI, or from code here in the notebook:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ccc6add6-f3da-49ce-9ecb-1cf588392396",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exec_1_desc = fmbench_execution_1.describe()\n",
+    "print(f\"Pipeline run status: {exec_1_desc['PipelineExecutionStatus']}\\n\")\n",
+    "\n",
+    "exec_1_steps = fmbench_execution_1.list_steps()\n",
+    "exec_1_steps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73eca008-e2df-4b82-aa7d-3ff60026f5f3",
+   "metadata": {},
+   "source": [
+    "▶️ **TODO:** Can you edit the `ConfigS3Uri` parameter in the below cell to trigger an additional run of the pipeline to test the **other** model that wasn't in the default run?\n",
+    "\n",
+    "Use the default pipeline parameters above as a guide, and check out which other config(s) were downloaded from this bucket that you could use."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a1847ef-be3c-4f19-be62-3fc77e584201",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fmbench_execution_2 = fmbench_pipeline.start(\n",
+    "    parameters={\n",
+    "        \"ConfigS3Uri\": \"TODO: Replace with your alternative s3://... URI\"\n",
+    "    },\n",
+    "    # You can also optionally name each pipeline execution for tracking purposes:\n",
+    "    # execution_display_name=\"llama3-run-1\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97f20862-c14d-41ef-960c-afe151559fe8",
+   "metadata": {},
+   "source": [
+    "### Exploring FMBench results\n",
+    "\n",
+    "When (one or both of) your pipeline runs have finished, you can explore the detailed results and reports saved by FMBench to Amazon S3.\n",
+    "\n",
+    "The below code will wait for both pipeline runs, and then copy the contents of the output bucket (assuming you didn't override it in the pipeline parameters) here in the notebook:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4bdffbd2-dbb5-4b9c-a8b4-a126ce8e489b",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Wait for both pipeline runs to finish:\n",
+    "fmbench_execution_1.wait()\n",
+    "fmbench_execution_2.wait()\n",
+    "\n",
+    "# Look up the (default) S3 output location for the runs:\n",
+    "try:\n",
+    "    default_output_bucket = next(\n",
+    "        p for p in pipeline_params if p[\"Name\"] == \"OutputS3BucketName\"\n",
+    "    )[\"DefaultValue\"]\n",
+    "except StopIteration as e:\n",
+    "    raise ValueError(\n",
+    "        f\"Couldn't find 'OutputS3BucketName' parameter in pipeline parameters: {pipeline_params}\"\n",
+    "    )\n",
+    "\n",
+    "# Download the S3 output folder locally:\n",
+    "print(\"Downloading FMBench results...\\n\")\n",
+    "!aws s3 sync s3://{default_output_bucket}/ data/fmbench_outputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87c7fa11-af1c-4ff1-9399-1ac7f05b23c4",
+   "metadata": {},
+   "source": [
+    "You'll see separate subfolders created in the outputs for each model/experiment you ran, and the `metrics` subfolder will contain detailed reports including a `business_summary.html`, `tokens_vs_latency.png` chart, and a range of other data and charts."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "284bb7d1-c14e-4c52-a8c2-e4760f8aadff",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "Particularly for real-time or high-volume applications, it's important to assess and evaluate potential trade-offs between the achievable quality of responses, versus the speed and cost-to-serve.\n",
+    "\n",
+    "In this notebook we briefly explored two different tools for latency and throughput testing:\n",
+    "\n",
+    "- [**LLMeter**](https://github.com/awslabs/llmeter#readme), from AWS Labs:\n",
+    "    - is straightforward to install\n",
+    "    - connects to OpenAI and a range of other 3rd-party model providers, as well as AWS-hosted models\n",
+    "    - includes pre-built \"experiments\" for mapping latency by prompt+completion length, and performance by number of concurrent clients/requests\n",
+    "    - keeps a simple API for defining more customized test runs and drilling further into the metrics\n",
+    "- [**FMBench**](https://aws-samples.github.io/foundation-model-benchmarking-tool/), from AWS Samples:\n",
+    "    - brings in AWS pricing information to directly link latency and throughput metrics to cost-of-ownership\n",
+    "    - offers some response quality evaluations as well as performance (based on LongBench and LLM-judged evaluations by default)\n",
+    "    - requires some more complex setup and configuration due to its feature set, but this complexity can be contained by packaging the tool in a SageMaker Pipeline as we showed here\n",
+    " \n",
+    "You can find more detailed information and feature updates on the tools' own websites.\n",
+    "\n",
+    "Whatever tooling you use, accounting for response speed and cost considerations can help you:\n",
+    "- Make informed trade-offs to select the best model for your use-case\n",
+    "- Understand potential latency & cost rewards for optimizing the length of your prompt templates, typical output generations, and hard `max_tokens` limits on generation length"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/Latency and Cost.ipynb
+++ b/Latency and Cost.ipynb
@@ -514,6 +514,8 @@
     "    - offers some response quality evaluations as well as performance (based on LongBench and LLM-judged evaluations by default)\n",
     "    - requires some more complex setup and configuration due to its feature set, but this complexity can be contained by packaging the tool in a SageMaker Pipeline as we showed here\n",
     " \n",
+    "> ⚠️ **Warning:** It's important to note that both of these tools test *end-to-end* performance including network latency and any other bottlenecks from the machine where they run. Since Large Language Models are generally compute-intensive, this is often not a significant concern - but do double-check you're not likely to saturate the resources like network or compute of your test host (i.e. notebook or SageMaker processing job instance) when you run larger-scale tests.\n",
+    " \n",
     "You can find more detailed information and feature updates on the tools' own websites.\n",
     "\n",
     "Whatever tooling you use, accounting for response speed and cost considerations can help you:\n",

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ To customize and re-deploy this app, or run the container locally, see the docum
 
 For users who are familiar with Python and comfortable running code, we provide example notebooks demonstrating other evaluation techniques:
 
+- [Latency and Cost.ipynb](Latency%20and%20Cost.ipynb) shows open-source tools (including [LLMeter](https://github.com/awslabs/llmeter#readme) and [FMBench](https://github.com/aws-samples/foundation-model-benchmarking-tool#readme)) that you can use to profile the latency, throughput, and therefore cost-to-serve of various LLMs and deployment types.
 - [LLM-Based Critique (Bedrock and fmeval).ipynb](LLM-Based%20Critique%20(Bedrock%20and%20fmeval).ipynb) demonstrates LLM-judged evaluation for a supervised, in-context question answering use-case, using models on Amazon Bedrock and orchestrating the process via the [open-source `fmeval` library](https://github.com/aws/fmeval).
 - [LLM-Based Critique (SageMaker and Claude).ipynb](LLM-Based%20Critique%20(SageMaker%20and%20Claude).ipynb) shows LLM-judged evaluation for a weakly-supervised, text summarization use-case, using Anthropic Claude on Amazon Bedrock to evaluate open-source models deployed on SageMaker.
 - [RAG (Bedrock and Ragas).ipynb](RAG%20(Bedrock%20and%20Ragas).ipynb) explores how the open-source [Ragas](https://docs.ragas.io/en/latest/) framework can be used to test integrated Retrieval-Augmented-Generation (RAG) flows with a suite of specialized, LLM-judged evaluation metrics.
@@ -126,11 +127,6 @@ You may need to manually delete the container image(s) from your `sm-fmbench` re
 
 1. Delete any [SageMaker Endpoints](https://console.aws.amazon.com/sagemaker/home?#/endpoints) you may have deployed for testing Mistral and Llama models in workshop lab 1
 2. Delete the [Bedrock Knowledge Base](https://console.aws.amazon.com/bedrock/home?#/knowledge-bases) you may have deployed for exploring RAG and end-to-end testing
-
-
-## Further reading and tools
-
-- [FMBench](https://github.com/aws-samples/foundation-model-benchmarking-tool) is an open-source Python package from AWS that can help run performance and cost benchmarking of foundation models deployed on Amazon SageMaker and Amazon Bedrock.
 
 
 ## Security


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

Add an example notebook for latency & throughput testing with both LLMeter (simple Python-only tool) and the deployed SageMaker pipelines for FMBench.

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
